### PR TITLE
Enhance/search hyperparam config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+API_PORT=9000
+# DB
+DB_HOST=
+DB_NAME=
+DB_USERNAME=
+DB_PASSWORD=
+DB_CLASSNAME=
+DB_PORT=
+
+# 검색 점수 가중치
+SEARCH_ALPHA=0.5     # 텍스트 유사도 가중치
+SEARCH_BETA=0.5      # 태그 유사도 가중치
+
+# 태그 유사도 계산
+TAG_TOP_K=3                 # 포폴 태그 중 상위 K개 유사도만 평균
+TAG_SIM_THRESHOLD=0.5       # 벌점 적용 임계값
+TAG_PENALTY_FACTOR=3.0      # 벌점 강도

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -31,3 +31,10 @@ class EnvVariables:
             if key.endswith(postfix):
                 routes.append(value)
         return routes
+
+class SearchConfig:
+    ALPHA = float(os.getenv("SEARCH_ALPHA", 0.5))
+    BETA = float(os.getenv("SEARCH_BETA", 0.5))
+    TAG_TOP_K = int(os.getenv("TAG_TOP_K", 3))
+    TAG_SIM_THRESHOLD = float(os.getenv("TAG_SIM_THRESHOLD", 0.5))
+    TAG_PENALTY_FACTOR = float(os.getenv("TAG_PENALTY_FACTOR", 3.0))

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -7,6 +7,7 @@ import faiss
 from sentence_transformers import SentenceTransformer
 
 from app.core.database import get_db
+from app.core.config import SearchConfig
 from app.models.ptfo_tag_merged import PtfoTagMerged
 from app.schemas.search_dto import SearchDTO
 
@@ -107,9 +108,9 @@ class SearchService:
         # 3-2. 태그 유사도 계산 (Top-K + 벌점)
         #############################
         tag_similarity_scores = []
-        top_k = 3
-        penalty_threshold = 0.5
-        penalty_factor = 3.0
+        top_k = SearchConfig.TAG_TOP_K
+        penalty_threshold = SearchConfig.TAG_SIM_THRESHOLD
+        penalty_factor = SearchConfig.TAG_PENALTY_FACTOR
 
         if request.tags:
             query_tag_vectors = embedding_model.encode(request.tags, convert_to_numpy=True)
@@ -154,7 +155,8 @@ class SearchService:
         #############################
         # 3-3. 최종 점수 산출 및 정렬
         #############################
-        alpha, beta = 0.5, 0.5
+        alpha = SearchConfig.ALPHA
+        beta = SearchConfig.BETA
         final_scores = alpha * text_similarity_scores + beta * tag_similarity_scores
 
         results = []


### PR DESCRIPTION
# 검색 점수 계산 하이퍼파라미터 외부화

## 요약

이 PR은 포트폴리오 검색 및 랭킹 로직에서 사용되는 주요 하이퍼파라미터들을 .env 기반 설정으로 분리하여, 모델 튜닝과 실험 반복이 용이하도록 개선한 작업입니다.

---
## 주요 변경 사항

### 1. 검색 점수 계산 관련 파라미터 외부 설정화

   > 커밋: 🔧 chore: externalize hyperparameters for search scoring
  -	기존 하드코딩되어 있던 아래 파라미터들을 .env 설정값으로 분리:
  -	SEARCH_ALPHA: 텍스트 유사도 가중치
  -	SEARCH_BETA: 태그 유사도 가중치
  -	TAG_TOP_K: Top-K 태그 유사도 평균 개수
  -	TAG_SIM_THRESHOLD: 유사도 벌점 적용 임계값
  -	TAG_PENALTY_FACTOR: 벌점 강도
  -	설정은 아래와 같이 기본값을 가지며, 필요시 .env에서 조정 가능:
	    
      ```
      ALPHA = float(os.getenv("SEARCH_ALPHA", 0.5))
      TAG_TOP_K = int(os.getenv("TAG_TOP_K", 3))
      ...  
      ```
### 2. `.env.example` 템플릿 파일 추가
> 커밋: 📝 docs: add .env.example with search scoring hyperparameters
  -	환경변수 구성을 빠르게 참고할 수 있도록 .env.example 파일 생성
  -	포함 내용:
      -	서버 및 DB 접속 정보
      -	검색 알고리즘 파라미터 (가중치, 벌점 기준 등)

##  기대 효과
-	실험 시점마다 파라미터를 유연하게 조정 가능
-	모델 개선 작업을 위한 반복 실험이 수월해짐
-	코드 내 하드코딩 제거로 유지보수성 향상
-	협업 개발자/운영자에게 명확한 설정 가이드 제공
  