### PR TITLE
Feature/etl script

### DIFF
--- a/app/models/ptfo_tag_mapp.py
+++ b/app/models/ptfo_tag_mapp.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, CHAR
+from app.core.database import Base
+
+
+class PtfoTagMapp(Base):
+    __tablename__ = "tb_ptfo_tag_mapp"
+
+    PTFO_SEQNO = Column(Integer, primary_key=True)
+    TAG_SEQNO = Column(Integer, primary_key=True)
+    TAG_DSP_YN = Column(CHAR(1), nullable=True)
+    WR_PER_NO = Column(Integer, nullable=True)
+    WR_DTM = Column(String(14), nullable=True)

--- a/app/scripts/refresh_ptfo_tag_merged.py
+++ b/app/scripts/refresh_ptfo_tag_merged.py
@@ -9,7 +9,7 @@ from app.models.ptfo_tag_merged import PtfoTagMerged
 from app.core.database import SessionLocal
 from app.core.database import engine, Base
 
-# 테이블이 없으면 생성
+
 inspector = inspect(engine)
 if "tb_ptfo_tag_merged" not in inspector.get_table_names():
     print("tb_ptfo_tag_merged 테이블이 존재하지 않아 생성합니다.")
@@ -20,11 +20,9 @@ def populate_merged_table():
     db: Session = SessionLocal()
 
     try:
-        # 기존 merged 데이터 삭제
         db.query(PtfoTagMerged).delete()
         db.commit()
 
-        # 조인된 결과 생성
         joins = (
             db.query(
                 PtfoInfo.PTFO_SEQNO,
@@ -35,11 +33,10 @@ def populate_merged_table():
             )
             .join(PtfoTagMapp, PtfoInfo.PTFO_SEQNO == PtfoTagMapp.PTFO_SEQNO)
             .join(TagInfo, PtfoTagMapp.TAG_SEQNO == TagInfo.TAG_SEQNO)
-            .filter(PtfoTagMapp.TAG_DSP_YN == 'Y')  # 표출 대상만
+            .filter(PtfoTagMapp.TAG_DSP_YN == 'Y')
             .all()
         )
 
-        # merged 테이블에 insert
         for ptfo_seq, ptfo_nm, ptfo_desc, tag_seq, tag_nm in joins:
             merged = PtfoTagMerged(
                 PTFO_SEQNO=ptfo_seq,

--- a/app/scripts/refresh_ptfo_tag_merged.py
+++ b/app/scripts/refresh_ptfo_tag_merged.py
@@ -1,0 +1,61 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import inspect
+
+from app.models.ptfo_info import PtfoInfo
+from app.models.tag_info import TagInfo
+from app.models.ptfo_tag_mapp import PtfoTagMapp
+from app.models.ptfo_tag_merged import PtfoTagMerged
+
+from app.core.database import SessionLocal
+from app.core.database import engine, Base
+
+# 테이블이 없으면 생성
+inspector = inspect(engine)
+if "tb_ptfo_tag_merged" not in inspector.get_table_names():
+    print("tb_ptfo_tag_merged 테이블이 존재하지 않아 생성합니다.")
+    Base.metadata.create_all(bind=engine)
+
+
+def populate_merged_table():
+    db: Session = SessionLocal()
+
+    try:
+        # 기존 merged 데이터 삭제
+        db.query(PtfoTagMerged).delete()
+        db.commit()
+
+        # 조인된 결과 생성
+        joins = (
+            db.query(
+                PtfoInfo.PTFO_SEQNO,
+                PtfoInfo.PTFO_NM,
+                PtfoInfo.PTFO_DESC,
+                TagInfo.TAG_SEQNO,
+                TagInfo.TAG_NM
+            )
+            .join(PtfoTagMapp, PtfoInfo.PTFO_SEQNO == PtfoTagMapp.PTFO_SEQNO)
+            .join(TagInfo, PtfoTagMapp.TAG_SEQNO == TagInfo.TAG_SEQNO)
+            .filter(PtfoTagMapp.TAG_DSP_YN == 'Y')  # 표출 대상만
+            .all()
+        )
+
+        # merged 테이블에 insert
+        for ptfo_seq, ptfo_nm, ptfo_desc, tag_seq, tag_nm in joins:
+            merged = PtfoTagMerged(
+                PTFO_SEQNO=ptfo_seq,
+                PTFO_NM=ptfo_nm,
+                PTFO_DESC=ptfo_desc,
+                TAG_SEQNO=tag_seq,
+                TAG_NM=tag_nm
+            )
+            db.add(merged)
+
+        db.commit()
+        print(f"merged 테이블 생성 완료: 총 {len(joins)}건")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    populate_merged_table()


### PR DESCRIPTION
### 데이터 정리 스크립트화

> tb_ptfo_info, tb_tag_info → tb_ptfo_tag_merged 로 통합하는 ETL 스크립트
> 
- 데이터에 변동이 있을 시, 스크립트 시행으로 빠른 데이터 매핑 가능
- 태그 매핑이 자주 바뀌는 경우 ETL 스크립트가 유리함
    - 태그 수정, 비표출 처리(TAG_DSP_YN = ‘N’) 등이 일어날 수 있는 구조이기 때문에, 매번 merged 테이블을 재구성 할 필요가 있음

**구조**

- tb_ptfo_info: 포트폴리오 정보 (PTFO_SEQNO, PTFO_NM, PTFO_DESC)
- tb_tag_info: 태그 정보 (TAG_SEQNO, TAG_NM)
- tb_ptfo_tag_merged: 포폴-태그 매핑 테이블