### PR TITLE
[Docs] Implemented license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,75 @@
+Copyright (c) 2025 Somyeong Jeon
+ 
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+   (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+   Copyright (c) 2025 Somyeong Jeon
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+RAGvertise
+Copyright (c) 2025 Somyeong Jeon
+
+This product includes software developed by the RAGvertise project contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+For third-party dependencies, models, and datasets used by this project,
+see THIRD_PARTY_NOTICES.md.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RAGvertise
 English | [한국어](./README_KOR.md)
 
-![KTL Certified](https://img.shields.io/badge/KTL-Certified-success) ![Latency-2.66s](https://img.shields.io/badge/Latency-2.66s-informational) ![ROUGE1F1-0.91](https://img.shields.io/badge/ROUGE--1%20F1-0.91-blue)  
+![License](https://img.shields.io/badge/License-Apache--2.0-red.svg) ![KTL Certified](https://img.shields.io/badge/KTL-Certified-success) ![Latency-2.66s](https://img.shields.io/badge/Latency-2.66s-informational) ![ROUGE1F1-0.91](https://img.shields.io/badge/ROUGE--1%20F1-0.91-blue)  
 
 ## 📑 Table of Contents
 

--- a/README_KOR.md
+++ b/README_KOR.md
@@ -1,7 +1,7 @@
 # RAGvertise
 한국어 | [English](./README.md)
 
-![KTL Certified](https://img.shields.io/badge/KTL-Certified-success) ![Latency-2.66s](https://img.shields.io/badge/Latency-2.66s-informational) ![ROUGE1F1-0.91](https://img.shields.io/badge/ROUGE--1%20F1-0.91-blue)  
+![License](https://img.shields.io/badge/License-Apache--2.0-red.svg) ![KTL Certified](https://img.shields.io/badge/KTL-Certified-success) ![Latency-2.66s](https://img.shields.io/badge/Latency-2.66s-informational) ![ROUGE1F1-0.91](https://img.shields.io/badge/ROUGE--1%20F1-0.91-blue)  
 
 ## 📑 목차
 ****

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,280 @@
+# Third-Party Notices
+_Last updated: 2025-09-24_
+
+This document lists third-party software, models, datasets, tools, and frameworks used by the **RAGvertise** project.  
+Please update this file as dependencies change.
+
+---
+
+## Libraries
+
+> **Python (from `requirements.txt`)** — versions per repo: faiss-cpu **1.10.0**, fastapi **0.115.8**, fasttext **0.9.3**, huggingface-hub **0.28.1**, numpy **1.26.4**, ollama **0.4.7**, scikit-learn **1.6.1**, scipy **1.13.1**, sentence-transformers **3.4.1**, starlette **0.45.3**, transformers **4.48.3**, torch **2.6.0**, torchaudio **2.6.0**, torchvision **0.21.0**, uvicorn **0.34.0**, uvloop **0.21.0**, PyYAML **6.0.2**, requests **2.32.3**, SQLAlchemy **2.0.38**, etc.
+
+- **annotated-types**
+  - Version: 0.7.0
+  - License: MIT (common) — verify
+  - Homepage/Repo: https://pypi.org/project/annotated-types/
+  - Notes: Typing helpers
+
+- **anyio**
+  - Version: 4.8.0
+  - License: MIT — verify
+  - Homepage/Repo: https://github.com/agronholm/anyio
+  - Notes: Async networking
+
+- **beautifulsoup4**
+  - Version: 4.13.4
+  - License: MIT
+  - Homepage/Repo: https://www.crummy.com/software/BeautifulSoup/
+  - Notes: HTML parsing
+
+- **faiss-cpu**
+  - Version: 1.10.0
+  - License: MIT
+  - Homepage/Repo: https://github.com/facebookresearch/faiss
+  - Notes: Vector similarity
+
+- **fastapi**
+  - Version: 0.115.8
+  - License: MIT
+  - Homepage/Repo: https://github.com/tiangolo/fastapi
+  - Notes: Backend web framework
+
+- **fasttext**
+  - Version: 0.9.3
+  - License: MIT
+  - Homepage/Repo: https://github.com/facebookresearch/fastText
+  - Notes: Word embeddings
+
+- **gensim**
+  - Version: 4.3.3
+  - License: LGPL-2.1-or-later — verify
+  - Homepage/Repo: https://github.com/RaRe-Technologies/gensim
+  - Notes: NLP utilities
+
+- **google-auth / googleapis-common-protos / grpcio / grpcio-status / httplib2**
+  - Version: 2.40.3 / 1.70.0 / 1.73.0 / 1.71.0 / 0.22.0
+  - License: Apache-2.0 — verify
+  - Homepage: various Google OSS repos
+  - Notes: Google API client stack
+
+- **google-genai**
+  - Version: 1.19.0
+  - License: TBD (verify on project site)
+  - Homepage/Repo: https://pypi.org/project/google-genai/
+  - Notes: Google Generative AI client
+
+- **huggingface-hub**
+  - Version: 0.28.1
+  - License: Apache-2.0
+  - Homepage/Repo: https://github.com/huggingface/huggingface_hub
+  - Notes: Model hub client
+
+- **numpy**
+  - Version: 1.26.4
+  - License: BSD-3-Clause
+  - Homepage/Repo: https://github.com/numpy/numpy
+  - Notes: Numerical computing
+
+- **mysql-connector-python / PyMySQL / SQLAlchemy**
+  - Version: 9.2.0 / 1.1.1 / 2.0.38
+  - License: (Oracle) Commercial/Community / MIT / MIT — verify mysql-connector terms
+  - Homepage/Repo: respective project pages
+  - Notes: Database connectivity & ORM
+
+- **ollama (Python client)**
+  - Version: 0.4.7
+  - License: MIT — verify
+  - Homepage/Repo: https://pypi.org/project/ollama/
+  - Notes: Client for local model server
+
+- **pydantic / pydantic_core**
+  - Version: 2.10.6 / 2.27.2
+  - License: MIT
+  - Homepage/Repo: https://github.com/pydantic/pydantic
+  - Notes: Data validation
+
+- **requests / httpx / anyio / h11 / httpcore**
+  - Version: 2.32.3 / 0.28.1 / 4.8.0 / 0.14.0 / 1.0.7
+  - License: Apache-2.0 (requests), BSD-3 (httpx) — verify for each
+  - Homepage/Repo: respective project pages
+  - Notes: HTTP clients & ASGI stack
+
+- **scikit-learn**
+  - Version: 1.6.1
+  - License: BSD-3-Clause
+  - Homepage/Repo: https://github.com/scikit-learn/scikit-learn
+  - Notes: ML utilities
+
+- **scipy**
+  - Version: 1.13.1
+  - License: BSD-3-Clause
+  - Homepage/Repo: https://github.com/scipy/scipy
+  - Notes: Scientific computing
+
+- **sentence-transformers**
+  - Version: 3.4.1
+  - License: Apache-2.0
+  - Homepage/Repo: https://github.com/UKPLab/sentence-transformers
+  - Notes: SBERT embeddings
+
+- **starlette**
+  - Version: 0.45.3
+  - License: BSD-3-Clause
+  - Homepage/Repo: https://github.com/encode/starlette
+  - Notes: ASGI toolkit (FastAPI base)
+
+- **tokenizers**
+  - Version: 0.21.0
+  - License: Apache-2.0
+  - Homepage/Repo: https://github.com/huggingface/tokenizers
+  - Notes: HF tokenizers (Rust/Py)
+
+- **torch / torchaudio / torchvision**
+  - Version: 2.6.0 / 2.6.0 / 0.21.0
+  - License: BSD-3-Clause (PyTorch) — verify
+  - Homepage/Repo: https://pytorch.org/
+  - Notes: Deep learning framework
+
+- **transformers**
+  - Version: 4.48.3
+  - License: Apache-2.0
+  - Homepage/Repo: https://github.com/huggingface/transformers
+  - Notes: LLM pipelines
+
+- **tqdm**
+  - Version: 4.67.1
+  - License: MIT
+  - Homepage/Repo: https://github.com/tqdm/tqdm
+  - Notes: Progress bars
+
+- **uvicorn**
+  - Version: 0.34.0
+  - License: BSD-3-Clause
+  - Homepage/Repo: https://github.com/encode/uvicorn
+  - Notes: ASGI server
+
+- **uvloop**
+  - Version: 0.21.0
+  - License: MIT
+  - Homepage/Repo: https://github.com/MagicStack/uvloop
+  - Notes: Fast event loop
+
+> **Frontend (from `package.json`)** — dependencies: axios **^1.11.0**, react **^19.1.0**, react-dom **^19.1.0**, react-router-dom **^7.7.1**; devDependencies: @vitejs/plugin-react **^4.6.0**, vite **^7.0.4**, tailwindcss **^3.4.17**, typescript **~5.8.3**, eslint **^9.30.1** etc.
+
+- **axios**
+  - Version: ^1.11.0
+  - License: MIT
+  - Homepage/Repo: https://github.com/axios/axios
+  - Notes: HTTP client
+
+- **react / react-dom**
+  - Version: ^19.1.0 / ^19.1.0
+  - License: MIT
+  - Homepage/Repo: https://react.dev/
+  - Notes: UI library
+
+- **react-router-dom**
+  - Version: ^7.7.1
+  - License: MIT
+  - Homepage/Repo: https://github.com/remix-run/react-router
+  - Notes: Routing
+
+- **vite / @vitejs/plugin-react**
+  - Version: ^7.0.4 / ^4.6.0
+  - License: MIT
+  - Homepage/Repo: https://vitejs.dev/
+  - Notes: Build tool
+
+- **tailwindcss / postcss / autoprefixer**
+  - Version: ^3.4.17 / ^8.5.6 / ^10.4.21
+  - License: MIT
+  - Homepage/Repo: https://tailwindcss.com/
+  - Notes: Styling toolchain
+
+- **typescript**
+  - Version: ~5.8.3
+  - License: Apache-2.0
+  - Homepage/Repo: https://www.typescriptlang.org/
+  - Notes: TypeScript compiler
+
+- **eslint (+ plugins)**
+  - Version: ^9.30.1 (core)
+  - License: MIT
+  - Homepage/Repo: https://eslint.org/
+  - Notes: Linting
+
+---
+
+## Models
+
+- **Mistral 7B (via Ollama)**
+  - Provider: Mistral AI
+  - Version/Build: v0.3 (referenced)
+  - License/Terms: Apache-2.0 — verify with Ollama model card
+  - Source/URL: https://ollama.com/library/mistral
+  - Notes: Pulled at runtime via Ollama; weights are not redistributed in this repo
+
+- **intfloat/multilingual-e5-base**
+  - Provider: intfloat (Hugging Face)
+  - Version/Build: N/A
+  - License/Terms: Apache-2.0 (per model card; verify)
+  - Source/URL: https://huggingface.co/intfloat/multilingual-e5-base
+  - Notes: Sentence embeddings; downloaded at runtime
+
+- **fastText vectors (cc.ko.300.bin)**
+  - Provider: Facebook AI / fastText
+  - Version/Date: Common Crawl vectors (ko, 300d)
+  - License/Terms: CC BY-SA 3.0 (per fastText site) — verify
+  - Source/URL: https://fasttext.cc/docs/en/crawl-vectors.html
+  - Notes: Large external file; not stored in repo
+
+---
+
+## Datasets
+
+- **Internal Test Datasets (`test_data/tc*.json`)**
+  - Provider: Project-internal
+  - Version/Date: 2025-08 (KTL evaluation period)
+  - License/Terms: Internal use only; not redistributed
+  - Source/URL: Local repo paths (e.g., `test_data/tc2_dataset.json`)
+  - Notes: Used for KTL certification tests
+
+---
+
+## Tools and Frameworks
+
+- **Ollama**
+  - Version: 0.4.7 (Python client present; server installed locally)
+  - License: MIT — verify current server repo/license
+  - Homepage/Repo: https://github.com/ollama/ollama
+  - Notes: Local model serving runtime
+
+- **PyCharm**
+  - Version: 2025.2 (referenced)
+  - License: Proprietary (JetBrains)
+  - Homepage: https://www.jetbrains.com/pycharm/
+  - Notes: Development IDE; not redistributed
+
+- **macOS (Apple Silicon)**
+  - Version: Sequoia 15.6 (environment)
+  - License: Proprietary (Apple)
+  - Homepage: https://www.apple.com/macos/
+  - Notes: Host OS; not redistributed
+
+- **MySQL / MariaDB**
+  - Version: N/A
+  - License: GPL-2.0 (MySQL Community), GPL-2.0 (MariaDB) — verify enterprise terms if applicable
+  - Homepage: https://www.mysql.com/ / https://mariadb.org/
+  - Notes: External database servers; not redistributed
+
+---
+
+If any license requires attribution or the inclusion of its notice text, copy the required notice(s) into this file or link to the appropriate files within the dependency.
+
+---
+
+### Maintenance Tips
+- When you add or bump packages in `requirements.txt` or `package.json`, reflect the changes here.
+- If a model or dataset’s license is unclear, mark it `TBD` and add the source URL to review before distribution.
+- Keep this file in sync with your release tags.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/api/v1/endpoints/generate_router.py
+++ b/app/api/v1/endpoints/generate_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 
 from app.schemas.v1.generate_dto import GenerateDTO

--- a/app/api/v1/endpoints/healthcheck_router.py
+++ b/app/api/v1/endpoints/healthcheck_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter
 
 healthcheck_router = APIRouter()

--- a/app/api/v1/endpoints/rank_router.py
+++ b/app/api/v1/endpoints/rank_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 
 from app.schemas.v1.rank_dto import RankDTO

--- a/app/api/v1/endpoints/test_router.py
+++ b/app/api/v1/endpoints/test_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import ollama
 from fastapi import APIRouter, HTTPException, Depends
 

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter
 
 

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/api/v2/endpoints/ad_element_extractor_router.py
+++ b/app/api/v2/endpoints/ad_element_extractor_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 from app.schemas.v2.ad_element_extractor_dto import AdElementDTOV2
 from app.services.v2.ad_element_extractor_service import AdElementExtractorServiceV2

--- a/app/api/v2/endpoints/rank_router.py
+++ b/app/api/v2/endpoints/rank_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 from app.schemas.v2.rank_dto import RankDTOV2
 from app.services.v2.rank_service import RankServiceV2

--- a/app/api/v2/router.py
+++ b/app/api/v2/router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter
 from app.api.v2.endpoints import ad_element_extractor_router, rank_router
 

--- a/app/api/v3/__init__.py
+++ b/app/api/v3/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/api/v3/endpoints/ad_element_extractor_router.py
+++ b/app/api/v3/endpoints/ad_element_extractor_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 from app.schemas.v2.ad_element_extractor_dto import AdElementDTOV2
 from app.services.v2.ad_element_extractor_service import AdElementExtractorServiceV2

--- a/app/api/v3/endpoints/production_example_router.py
+++ b/app/api/v3/endpoints/production_example_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 from starlette.concurrency import run_in_threadpool
 

--- a/app/api/v3/endpoints/rank_router.py
+++ b/app/api/v3/endpoints/rank_router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter, HTTPException
 from app.schemas.v3.rank_dto import RankDTOV3
 from app.services.v3.rank_service import RankServiceV3

--- a/app/api/v3/router.py
+++ b/app/api/v3/router.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import APIRouter
 from app.api.v3.endpoints import ad_element_extractor_router, rank_router, production_example_router
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 from dotenv import load_dotenv
 

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import declarative_base

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/preprocess/__init__.py
+++ b/app/preprocess/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/preprocess/v1/__init__.py
+++ b/app/preprocess/v1/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/preprocess/v2/__init__.py
+++ b/app/preprocess/v2/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/preprocess/v3/__init__.py
+++ b/app/preprocess/v3/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/schemas/v1/__init__.py
+++ b/app/schemas/v1/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/schemas/v1/generate_dto.py
+++ b/app/schemas/v1/generate_dto.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 from pydantic import BaseModel

--- a/app/schemas/v1/rank_dto.py
+++ b/app/schemas/v1/rank_dto.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Optional
 
 from pydantic import BaseModel

--- a/app/schemas/v1/search_dto.py
+++ b/app/schemas/v1/search_dto.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
 

--- a/app/schemas/v1/test_dto.py
+++ b/app/schemas/v1/test_dto.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
 

--- a/app/schemas/v2/__init__.py
+++ b/app/schemas/v2/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/schemas/v2/ad_element_extractor_dto.py
+++ b/app/schemas/v2/ad_element_extractor_dto.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
 class AdElementDTOV2:

--- a/app/schemas/v3/__init__.py
+++ b/app/schemas/v3/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/services/v1/__init__.py
+++ b/app/services/v1/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/services/v1/generate_service.py
+++ b/app/services/v1/generate_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import ollama
 
 from app.schemas.v1.generate_dto import GenerateDTO

--- a/app/services/v1/rank_service.py
+++ b/app/services/v1/rank_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from app.schemas.v1.rank_dto import RankDTO
 from app.services.v1.generate_service import GenerateService
 from app.services.v1.search_service import SearchService

--- a/app/services/v1/search_service.py
+++ b/app/services/v1/search_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 import os
 import pickle

--- a/app/services/v2/__init__.py
+++ b/app/services/v2/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/services/v2/ad_element_extractor_service.py
+++ b/app/services/v2/ad_element_extractor_service.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 import json
 import re

--- a/app/services/v2/portfolio_service.py
+++ b/app/services/v2/portfolio_service.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from sqlalchemy.orm import Session
 
 from app.models.ptfo_tag_merged import PtfoTagMerged

--- a/app/services/v2/rank_service.py
+++ b/app/services/v2/rank_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from app.preprocess.text_cleaner import TextCleaner
 from app.schemas.v2.ad_element_extractor_dto import AdElementDTOV2
 from app.schemas.v2.rank_dto import RankDTOV2

--- a/app/services/v2/search_service.py
+++ b/app/services/v2/search_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Dict, Tuple
 import os
 import pickle

--- a/app/services/v3/__init__.py
+++ b/app/services/v3/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/app/services/v3/ad_production_example_service.py
+++ b/app/services/v3/ad_production_example_service.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import logging
 import time

--- a/app/services/v3/portfolio_service.py
+++ b/app/services/v3/portfolio_service.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import List, Dict
 from sqlalchemy.orm import Session
 

--- a/app/services/v3/rank_service.py
+++ b/app/services/v3/rank_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from app.core.config import RankConfig
 from app.preprocess.text_cleaner import TextCleaner
 from app.schemas.v2.ad_element_extractor_dto import AdElementDTOV2

--- a/app/services/v3/search_service.py
+++ b/app/services/v3/search_service.py
@@ -17,7 +17,7 @@ from app.models.ptfo_tag_merged import PtfoTagMerged
 
 class SearchServiceV3:
     """
-    - 부팅 시 1회 로드(싱글턴): fused_index / factor embeddings / records / weights / tag mapping
+    - 부팅 시 1회 로드(싱글톤): fused_index / factor embeddings / records / weights / tag mapping
     - 요청 시: fused 인덱스에서 후보 M 검색 → 후보에 한해 factor별 점수 및 최종 점수 계산
     - diversity=true면 후보 M을 더 넉넉히 가져와 MMR로 재랭킹
     - 필요 시 스튜디오 통계(PRDN_STDO_NM) 집계까지 반환
@@ -101,7 +101,7 @@ class SearchServiceV3:
         q_fused = np.concatenate(scaled, axis=1).astype(np.float32)
         return q_fused, q
 
-    # ---------- 펄블락 검색 ----------
+    # ---------- 퍼블릭 검색 ----------
     def search(
         self,
         request: SearchDTOV3.SearchRequest,

--- a/app/services/v3/search_service.py
+++ b/app/services/v3/search_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from collections import Counter
 from typing import List, Dict, Tuple, Optional
 import os
@@ -16,7 +17,7 @@ from app.models.ptfo_tag_merged import PtfoTagMerged
 
 class SearchServiceV3:
     """
-    - 부팅 시 1회 로드(싱글톤): fused_index / factor embeddings / records / weights / tag mapping
+    - 부팅 시 1회 로드(싱글턴): fused_index / factor embeddings / records / weights / tag mapping
     - 요청 시: fused 인덱스에서 후보 M 검색 → 후보에 한해 factor별 점수 및 최종 점수 계산
     - diversity=true면 후보 M을 더 넉넉히 가져와 MMR로 재랭킹
     - 필요 시 스튜디오 통계(PRDN_STDO_NM) 집계까지 반환
@@ -100,7 +101,7 @@ class SearchServiceV3:
         q_fused = np.concatenate(scaled, axis=1).astype(np.float32)
         return q_fused, q
 
-    # ---------- 퍼블릭 검색 ----------
+    # ---------- 펄블락 검색 ----------
     def search(
         self,
         request: SearchDTOV3.SearchRequest,

--- a/app/utils/date_tool.py
+++ b/app/utils/date_tool.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from zoneinfo import ZoneInfo
 

--- a/app/utils/gemini_api.py
+++ b/app/utils/gemini_api.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import logging
 import time

--- a/app/utils/io_utils.py
+++ b/app/utils/io_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import sys
 
 

--- a/app/utils/json_extractor.py
+++ b/app/utils/json_extractor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import re
 

--- a/app/utils/log_utils.py
+++ b/app/utils/log_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import sys
 

--- a/app/utils/mmr_reranker.py
+++ b/app/utils/mmr_reranker.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 from typing import List
 

--- a/app/utils/ollama_api.py
+++ b/app/utils/ollama_api.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import ollama
 from app.core.config import ModelConfig

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export default {
   plugins: {
     tailwindcss: {},

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import './main.css';
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 

--- a/frontend/src/components/PromptForm.tsx
+++ b/frontend/src/components/PromptForm.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 interface PromptFormProps {

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
 export const Dialog: React.FC<{ open: boolean; onOpenChange: (open: boolean) => void; children: React.ReactNode }> = ({

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import './main.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/frontend/src/modals/ProductionExampleModal.tsx
+++ b/frontend/src/modals/ProductionExampleModal.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // src/modals/ProductionExampleModal.tsx
 import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";

--- a/frontend/src/modals/ResponseModal.tsx
+++ b/frontend/src/modals/ResponseModal.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {NavigateFunction, useNavigate} from "react-router-dom";

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react';
 import PromptForm from '@/components/PromptForm';
 import ResultModal from '@/modals/ResponseModal';

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,7 +5,8 @@ import ResultModal from '@/modals/ResponseModal';
 import { extractAdElements } from '@/services/api';
 
 export default function Home() {
-  const [result, setResult] = useState(null);
+  // 타입 명시: extractAdElements 반환 타입 또는 null
+  const [result, setResult] = useState<Awaited<ReturnType<typeof extractAdElements>> | null>(null);
   const [loading, setLoading] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [prompt, setPrompt] = useState('');
@@ -17,7 +18,7 @@ export default function Home() {
       const res = await extractAdElements(input);
       setResult(res);
       setIsModalOpen(true);
-    } catch (e) {
+    } catch {
       alert('API 요청 중 오류가 발생했습니다.');
     } finally {
       setLoading(false);

--- a/frontend/src/pages/PromptPage.tsx
+++ b/frontend/src/pages/PromptPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { useState } from "react";
 import { extractAdElements } from "@/services/api";
 import PromptForm from "../components/PromptForm";

--- a/frontend/src/pages/PromptPage.tsx
+++ b/frontend/src/pages/PromptPage.tsx
@@ -6,7 +6,8 @@ import ResponseModal from "../modals/ResponseModal";
 
 export default function PromptPage() {
   const [prompt, setPrompt] = useState("");
-  const [response, setResponse] = useState(null);
+  // 타입 명시: extractAdElements 반환 타입 또는 null
+  const [response, setResponse] = useState<Awaited<ReturnType<typeof extractAdElements>> | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 

--- a/frontend/src/pages/RankResultPage.tsx
+++ b/frontend/src/pages/RankResultPage.tsx
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // src/pages/RankResultPage.tsx
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import axios from "axios";
 import type {
   RankResponseV3,

--- a/frontend/src/types/adElement.ts
+++ b/frontend/src/types/adElement.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export interface AdElementResponse {
   desc: string;
   what: string;

--- a/frontend/src/types/production.ts
+++ b/frontend/src/types/production.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 export type Tag = string;
 
 export interface Generated {
@@ -59,4 +60,10 @@ export interface ProductionExampleRequest {
 
 export interface ProductionExampleResponse {
   example: string;
+}
+
+export interface TopStudioStat {
+  name: string;
+  count: number;
+  ratio: number;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     "./index.html",
@@ -7,4 +9,4 @@ module.exports = {
     extend: {},
   },
   plugins: [],
-};
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import * as path from 'path';


### PR DESCRIPTION


## 📌 Related Issues
- Resolves #24 

___ 

## ✨ Work Description
Implemented Apache-2.0 license adoption and repository license compliance markup tasks.

- Added Apache License 2.0 full text (LICENSE) at the repository root
- Added NOTICE file (project name, copyright notice, Apache-2.0 notice, link to third-party notices)
- Authored/updated THIRD_PARTY_NOTICES.md (systematic inventory of backend/frontend libraries, models, datasets, tools; some entries marked with `verify` for follow-up review)
- Added and maintained an Apache-2.0 badge at the top of README (below H1)
- Inserted SPDX headers across source files (no code logic changes)
  - Python: `app/**` (API routers, services, schemas, utils, preprocess, model packages including __init__.py)
  - Frontend: `frontend/**` TS/TSX/JS (including config files like vite.config.ts, tailwind/postcss, etc.)
  - Excluded: submodules, third-party/vendor code, binaries, data files (fastText, build outputs, etc.)

___ 

## 🔎 Detailed Description
- **LICENSE**
  - Added Apache License, Version 2.0 full text at the root
  - Top copyright notice: `Copyright (c) 2025 Somyeong Jeon`

- **NOTICE**
  - Project name: RAGvertise
  - Apache-2.0 license notice and distribution conditions
  - Linked to third-party notices (THIRD_PARTY_NOTICES.md)

- **THIRD_PARTY_NOTICES.md**
  - Structured into “Libraries / Models / Datasets / Tools and Frameworks”
  - Populated with dependencies from `requirements.txt` and `package.json`
  - Some licenses marked `verify` pending final validation
  - Models/datasets are not bundled in repo; only references and license/terms URLs provided

- **README**
  - Inserted Apache-2.0 badge immediately below the H1 (kept existing badges intact)
  - Maintained KTL section and anchors / English translations

- **SPDX headers**
  - Python: first line `# SPDX-License-Identifier: Apache-2.0`
  - JS/TS/TSX: first line `// SPDX-License-Identifier: Apache-2.0`
  - No logic/type changes (only added 1 comment line)
  - Excluded third-party, submodules, and build artifacts

Notes:
- Verified with global search that `SPDX-License-Identifier` is applied across backend/frontend main sources.
- Some TypeScript files may still show warnings (unused vars, setState typing, etc.), but per “no logic/type changes” policy, these are left untouched. Recommend separate PR for lint/type cleanup.

___ 

## 🧪 Tests
- [x] LICENSE/NOTICE/THIRD_PARTY_NOTICES.md existence and contents verified
- [x] README license badge displayed correctly
- [x] Verified `SPDX-License-Identifier` comments present across backend/frontend via global grep
- [ ] Local server/frontend runtime check (recommended in separate issue/sprint)

Test notes:
- This PR changes documentation/comments only, no functional impact.
- Runtime/build checks should be performed in team’s standard environment.

___ 

## ➕ Etc.
- External large model files (e.g., fastText vectors) are excluded from repo (`.gitignore` recommended).
- Items marked with `verify` in THIRD_PARTY_NOTICES.md should be finalized before release.
- Badge color/style in README may be adjusted freely if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added Apache-2.0 LICENSE and NOTICE files and a comprehensive THIRD_PARTY_NOTICES document; README and Korean README display a license badge.
- Chores
  - Inserted SPDX Apache-2.0 license headers across backend and frontend source files.
- Frontend
  - Introduced a new exported type for studio statistics.
- Style
  - Minor config/comment cleanups with no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->